### PR TITLE
null pointer workaround

### DIFF
--- a/src/main/scala/activemq/cli/util/Implicits.scala
+++ b/src/main/scala/activemq/cli/util/Implicits.scala
@@ -77,12 +77,20 @@ object Implicits {
                                } </properties>)
                              }
                              {
-                               message match {
-                                 case textMessage: TextMessage ⇒ addOptional(
-                                   textMessage.getText,
-                                   <body>{ scala.xml.PCData(textMessage.getText.replaceAll("]]>", "]]]]><![CDATA[>")) }</body>
-                                 )
-                                 case _⇒ scala.xml.NodeSeq.Empty
+                               try {
+                                 message match {
+                                   case textMessage: TextMessage ⇒ addOptional(
+                                     textMessage.getText,
+                                     <body>
+                                       { scala.xml.PCData(textMessage.getText.replaceAll("]]>", "]]]]><![CDATA[>")) }
+                                     </body>
+                                   )
+                                   case _⇒ scala.xml.NodeSeq.Empty
+                                 }
+                               } catch {
+                                 case e: NullPointerException ⇒
+                                   println(s"warning: ${e.getMessage}\n")
+                                   scala.xml.NodeSeq.Empty
                                }
                              }
                            </jms-message>)


### PR DESCRIPTION
workaround for null pointer error crash that stopped me dumping a dead-letter queue (https://github.com/antonwierenga/activemq-cli/issues/4).

Tested the resultant xml as valid with xmllint.