### PR TITLE
Changed 'Commands.scala' to handle JMX failover URLs.

### DIFF
--- a/src/main/scala/activemq/cli/command/Commands.scala
+++ b/src/main/scala/activemq/cli/command/Commands.scala
@@ -166,15 +166,17 @@ abstract class Commands extends PrintStackTraceExecutionProcessor {
 
               brokerViewMBeans.headOption match {
                 case Some(brokerViewMBean) ⇒ {
-                  connectionMessage = callback(brokerViewMBean, jmxConnector.getMBeanServerConnection())
                   isConnected = true
+                  connectionMessage = callback(brokerViewMBean, jmxConnector.getMBeanServerConnection())
                 }
                 case _ ⇒ {
                   connectionMessage = "Broker not found"
                 }
               }
             } catch {
-              case illegalArgumentException: IllegalArgumentException ⇒ connectionMessage = warn(illegalArgumentException.getMessage)
+              case illegalArgumentException: IllegalArgumentException ⇒ {
+                connectionMessage = warn(illegalArgumentException.getMessage)
+              }
             } finally {
               jmxConnector.close
             }


### PR DESCRIPTION
'Command.scala' has been changed to handle failover URLs for ActiveMQ clusters. Specifying an ActiveMQ failover URL, e.g. `failover:(tcp://ampq-master.com:61616,tcp://ampq-slave-1.com:61616,tcp://ampq-slave-2.com:61616)` for property "amqurl" worked out of the box. But specifying a comma separated list of JMX URLs did not work. This merge request enables the "jmxurl" property to hold a simple comma separated list of URLs, which are tested one-by-one for a connection. The idea of the change was inspired by the JMSToolBox utility that allows up to three JMX URLs that are tested one-by-one. Please note that I am not a Scala developer and hence it might be necessary to improve my change.

Example properties:

```
broker {
	local {
	    amqurl = "failover:(tcp://localhost:61616,tcp://localhost:61617,tcp://localhost:61618)"
		jmxurl = "service:jmx:rmi:///jndi/rmi://localhost:1099/jmxrmi,service:jmx:rmi:///jndi/rmi://localhost:1199/jmxrmi,service:jmx:rmi:///jndi/rmi://localhost:1299/jmxrmi"
		username = ""
		password = ""
		prompt-color = "light-blue" // Possible values: "gray", "red", "light-red", "light-green", "green", "light-yellow", "yellow", "light-blue", "blue", "light-purple", "purple", "light-cyan", "cyan", "light-white", "white"
	}

	// add additional brokers here
}
```
